### PR TITLE
Bump vexctl to v0.2.6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   vexctl-release:
     description: 'vexctl release version to be installed'
     required: false
-    default: '0.2.5'
+    default: '0.2.6'
   install-dir:
     description: 'Where to install the vexctl binary'
     required: false


### PR DESCRIPTION
This PR bumps the installed version of vexctk to v0.2.6

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
